### PR TITLE
Update golang from 1.15.2 to 1.16.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,2 +1,2 @@
-FROM golang:1.16 AS builder
+FROM golang:1.16.0 AS builder
 

--- a/script/tools/buf/Dockerfile
+++ b/script/tools/buf/Dockerfile
@@ -11,7 +11,7 @@ RUN apk --no-cache add --virtual .build curl \
   && apk del .build
 
 
-FROM golang:1.15.2 AS protoc-plugins-go
+FROM golang:1.16.0 AS protoc-plugins-go
 RUN mkdir /app
 WORKDIR /app
 COPY go.mod .


### PR DESCRIPTION
Here is golang 1.16.0, I hope it works.

<!--::action-update-go::
{"signed":{"name":"golang","updates":[{"path":"golang","previous":"1.15.2","next":"1.16.0"}]},"signature":"Ebe2KuomqKLDxR/Eq05H4E16CsYoHkunKA54kQL5Kl0I4NaB4facVgbX2LBnH6CXBYakdbDItlUIaXt3luPVtw=="}
-->