### PR TITLE
Update github.com/bufbuild/buf/releases from v0.43.1 to v0.43.2

### DIFF
--- a/script/tools/buf/Dockerfile
+++ b/script/tools/buf/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.13.5 AS buf
 
-ARG BUF_VERSION=v0.43.1
-ARG BUF_CHECKSUM=2c1c15f94007b76d5e504ea087c75a9d41afe1f7589aa5c9d8be59a0758a10a5
+ARG BUF_VERSION=v0.43.2
+ARG BUF_CHECKSUM=53933427cb5518830a3fcf11d3bd9b6e3fb36eae9086731484b8ab50630c9d09
 
 ARG BUFF_URL=https://github.com/bufbuild/buf/releases/download/${BUF_VERSION}/buf-Linux-x86_64
 RUN apk --no-cache add --virtual .build curl \


### PR DESCRIPTION
Here is github.com/bufbuild/buf/releases v0.43.2, I hope it works.

<!--::action-update-go::
{"signed":{"name":"protoc","updates":[{"path":"github.com/bufbuild/buf/releases","previous":"v0.43.1","next":"v0.43.2"}]},"signature":"hMPBWMXRGf95cuq5OjoSMpCNsO+ainlSuR+qEGoAQozweg8ppEajfuEr5uNVP3vuZ6HV+sX5Np35ZkcHwbyqmg=="}
-->