### PR TITLE
Update github.com/twitchtv/twirp from v8.0.0+incompatible to v8.1.0+incompatible

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/sirupsen/logrus v1.8.1
 	github.com/thepwagner/action-update v0.0.40
-	github.com/twitchtv/twirp v8.0.0+incompatible
+	github.com/twitchtv/twirp v8.1.0+incompatible
 	golang.org/x/time v0.0.0-20201208040808-7e3f01d25324 // indirect
 	google.golang.org/protobuf v1.26.0
 )

--- a/go.sum
+++ b/go.sum
@@ -599,8 +599,8 @@ github.com/thepwagner/action-update v0.0.40 h1:jni2d5WHK103KpWX4kRyWBoja6dmAxY0y
 github.com/thepwagner/action-update v0.0.40/go.mod h1:A4ljXKA6lRuYiv6LA1UbCb3VrEZdV0j5wEFjMoCqNrI=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
-github.com/twitchtv/twirp v8.0.0+incompatible h1:uYHA8+9cit/+LUfQjL6zo/0QDKTo4U2H/WAnJ6LfhBU=
-github.com/twitchtv/twirp v8.0.0+incompatible/go.mod h1:RRJoFSAmTEh2weEqWtpPE3vFK5YBhA6bqp2l1kfCC5A=
+github.com/twitchtv/twirp v8.1.0+incompatible h1:KGXanpa9LXdVE/V5P/tA27rkKFmXRGCtSNT7zdeeVOY=
+github.com/twitchtv/twirp v8.1.0+incompatible/go.mod h1:RRJoFSAmTEh2weEqWtpPE3vFK5YBhA6bqp2l1kfCC5A=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/urfave/cli v0.0.0-20171014202726-7bc6a0acffa5/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=
 github.com/urfave/cli v1.20.0/go.mod h1:70zkFmudgCuE/ngEzBv17Jvp/497gISqfk5gWijbERA=


### PR DESCRIPTION
Here is github.com/twitchtv/twirp v8.1.0+incompatible, I hope it works.

<!--::action-update-go::
{"signed":{"updates":[{"path":"github.com/twitchtv/twirp","previous":"v8.0.0+incompatible","next":"v8.1.0+incompatible"}]},"signature":"s9+Vc/PlYZ9jGQkJ3LUWS4BhDynmnpzv1iEhq+BmAk/RLalpkakKkl/KNTiaWipabLgjDFBW3oBUVAzkUsEiow=="}
-->